### PR TITLE
Tests/test interpreter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "portfolio-website",
-  "version": "0.0.0",
+  "name": "cody-fingerson-website",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "portfolio-website",
-      "version": "0.0.0",
+      "name": "cody-fingerson-website",
+      "version": "3.0.0",
       "dependencies": {
         "@tailwindcss/vite": "^4.1.3",
         "@uiw/codemirror-theme-dracula": "^4.23.10",
@@ -30,7 +30,8 @@
         "globals": "^15.15.0",
         "typescript": "~5.7.2",
         "typescript-eslint": "^8.24.1",
-        "vite": "^6.2.0"
+        "vite": "^6.2.0",
+        "vitest": "^3.1.1"
       }
     },
     "node_modules/@babel/runtime": {
@@ -766,6 +767,13 @@
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
       }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@lezer/common": {
       "version": "1.2.3",
@@ -1564,6 +1572,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "22.14.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.1.tgz",
+      "integrity": "sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
     "node_modules/@types/react": {
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.0.tgz",
@@ -1899,6 +1918,119 @@
         "vite": "^4 || ^5 || ^6"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.1.1.tgz",
+      "integrity": "sha512-q/zjrW9lgynctNbwvFtQkGK9+vvHA5UzVi2V8APrp1C6fG6/MuYYkmlx4FubuqLycCeSdHD5aadWfua/Vr0EUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.1.1",
+        "@vitest/utils": "3.1.1",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.1.1.tgz",
+      "integrity": "sha512-bmpJJm7Y7i9BBELlLuuM1J1Q6EQ6K5Ye4wcyOpOMXMcePYKSIYlpcrCm4l/O6ja4VJA5G2aMJiuZkZdnxlC3SA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.1.1",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.1.1.tgz",
+      "integrity": "sha512-dg0CIzNx+hMMYfNmSqJlLSXEmnNhMswcn3sXO7Tpldr0LiGmg3eXdLLhwkv2ZqgHb/d5xg5F7ezNFRA1fA13yA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.1.1.tgz",
+      "integrity": "sha512-X/d46qzJuEDO8ueyjtKfxffiXraPRfmYasoC4i5+mlLEJ10UvPb0XH5M9C3gWuxd7BAQhpK42cJgJtq53YnWVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.1.1",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.1.1.tgz",
+      "integrity": "sha512-bByMwaVWe/+1WDf9exFxWWgAixelSdiwo2p33tpqIlM14vW7PRV5ppayVXtfycqze4Qhtwag5sVhX400MLBOOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.1.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.1.1.tgz",
+      "integrity": "sha512-+EmrUOOXbKzLkTDwlsc/xrwOlPDXyVk3Z6P6K4oiCndxz7YLpp/0R0UsWVOKT0IXWjjBJuSMk6D27qipaupcvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.1.1.tgz",
+      "integrity": "sha512-1XIjflyaU2k3HMArJ50bwSh3wKWPD6Q47wz/NUSmRV0zNywPc4w79ARjg/i/aNINHwA+mIALhUVqD9/aUvZNgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.1.1",
+        "loupe": "^3.1.3",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.14.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
@@ -1962,6 +2094,16 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1993,6 +2135,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2001,6 +2153,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.2.0.tgz",
+      "integrity": "sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/chalk": {
@@ -2018,6 +2187,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/codemirror": {
@@ -2117,6 +2296,16 @@
         }
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2145,6 +2334,13 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.6.0.tgz",
+      "integrity": "sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.25.2",
@@ -2367,6 +2563,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2375,6 +2581,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.1.tgz",
+      "integrity": "sha512-/kP8CAwxzLVEeFrMm4kMmy4CCDlpipyA7MYLVrdJIkV0fYF0UaigQHRsxHiuY/GEea+bh4KSv3TIlgr+2UL6bw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -2987,6 +3203,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/loupe": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.3.tgz",
+      "integrity": "sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.17",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
+      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -3152,6 +3385,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.0.tgz",
+      "integrity": "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
       }
     },
     "node_modules/picocolors": {
@@ -3450,6 +3700,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3458,6 +3715,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
+      "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
@@ -3504,6 +3775,50 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.0.2.tgz",
+      "integrity": "sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -3594,6 +3909,14 @@
         "typescript": ">=4.8.4 <5.9.0"
       }
     },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -3675,6 +3998,99 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.1.1.tgz",
+      "integrity": "sha512-V+IxPAE2FvXpTCHXyNem0M+gWm6J7eRyWPR6vYoG/Gl+IscNOjXzztUhimQgTxaAoUoj40Qqimaa0NLIOOAH4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.0",
+        "es-module-lexer": "^1.6.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.1.1.tgz",
+      "integrity": "sha512-kiZc/IYmKICeBAZr9DQ5rT7/6bD9G7uqQEki4fxazi1jdVl2mWGzedtBs5s6llz59yQhVb7FFY2MbHzHCnT79Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "3.1.1",
+        "@vitest/mocker": "3.1.1",
+        "@vitest/pretty-format": "^3.1.1",
+        "@vitest/runner": "3.1.1",
+        "@vitest/snapshot": "3.1.1",
+        "@vitest/spy": "3.1.1",
+        "@vitest/utils": "3.1.1",
+        "chai": "^5.2.0",
+        "debug": "^4.4.0",
+        "expect-type": "^1.2.0",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "std-env": "^3.8.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinypool": "^1.0.2",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0",
+        "vite-node": "3.1.1",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.1.1",
+        "@vitest/ui": "3.1.1",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/w3c-keyname": {
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
@@ -3695,6 +4111,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.3",
@@ -32,6 +33,7 @@
     "globals": "^15.15.0",
     "typescript": "~5.7.2",
     "typescript-eslint": "^8.24.1",
-    "vite": "^6.2.0"
+    "vite": "^6.2.0",
+    "vitest": "^3.1.1"
   }
 }

--- a/public/sample-code.cos
+++ b/public/sample-code.cos
@@ -1,3 +1,59 @@
-create x = 10;
+// The main function of the program
+func main() {
+  // Variable declaration and arithmetic expressions
+  create x = 10;
+  create y = 5;
+  create z = x * y + (x - y);
 
-output(x);
+  output(z);
+
+  create addition = add(x, y);
+
+  output(addition);
+
+  create squareRoot = sqrt(z);
+  output(squareRoot);
+
+  // Conditional statement
+  if (x > y) {
+    output("x is greater than y");
+  } else {
+    output("x is not greater than y");
+  }
+
+  // Loop
+  create i = 0;
+  while (i < 3) {
+    output(i);
+    i = i + 1;
+  }
+
+  // For loop
+  for (create j = 0; j < 2; j = j + 1) {
+    output(j);
+  }
+
+  // Equality and comparison operators
+  output(x == 10);
+  output(y != 5);
+  output(x > y);
+  output(x <= 10);
+
+  // Unary operators
+  output(-x);
+  output(!false);
+
+  // String literal
+  create str = "hello";
+  output(str);
+
+  // Null literal
+  create nullVar = null;
+  output(nullVar);
+
+  // Parenthesized expression
+  create parenResult = (x + y) * 2;
+  output(parenResult);
+}
+
+main(); // Call the main function to execute!

--- a/src/lib/parser/Parser.test.ts
+++ b/src/lib/parser/Parser.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest'
+import { Parser } from './Parser'
+import { Token, TokenType } from '../scanner/Token'
+import { ExpressionStatement, CreateStatement } from './statements'
+import { Binary, Literal, Grouping } from './expressions'
+
+function makeToken(type: TokenType, lexeme = type.toString(), literal: any = null) {
+    return new Token(type, lexeme, literal, 1)
+}
+
+describe('Parser', () => {
+    it('parses a single numeric literal expression', () => {
+        const tokens = [
+            makeToken(TokenType.NUMBER, '1', 1),
+            makeToken(TokenType.SEMICOLON, ';'),
+            makeToken(TokenType.EOF, '')
+        ]
+        
+        const stmts = new Parser(tokens).parse()
+        expect(stmts).not.toBeNull()
+        expect(stmts).toHaveLength(1)
+
+        const stmt = (stmts as any)[0]
+        expect(stmt).toBeInstanceOf(ExpressionStatement)
+
+        const expr = stmt.expression
+        expect(expr).toBeInstanceOf(Literal)
+        expect((expr as Literal).value).toBe(1)
+    })
+
+    it('respects operator precedence in 1 + 2 * 3', () => {
+        const tokens = [
+            makeToken(TokenType.NUMBER, '1', 1),
+            makeToken(TokenType.PLUS, '+'),
+            makeToken(TokenType.NUMBER, '2', 2),
+            makeToken(TokenType.STAR, '*'),
+            makeToken(TokenType.NUMBER, '3', 3),
+            makeToken(TokenType.SEMICOLON, ';'),
+            makeToken(TokenType.EOF, '')
+        ]
+
+        const expr = (new Parser(tokens).parse() as any)[0].expression as Binary
+        expect(expr).toBeInstanceOf(Binary)
+        expect(expr.operator.type).toBe(TokenType.PLUS)
+        expect(expr.left).toBeInstanceOf(Literal)
+        expect((expr.left as Literal).value).toBe(1)
+
+        const right = expr.right as Binary
+        expect(right).toBeInstanceOf(Binary)
+        expect(right.operator.type).toBe(TokenType.STAR)
+        expect((right.left as Literal).value).toBe(2)
+        expect((right.right as Literal).value).toBe(3)
+    })
+
+    it('parses grouped expressions (1 + 2) * 3', () => {
+        const tokens = [
+            makeToken(TokenType.LEFT_PAREN, '('),
+            makeToken(TokenType.NUMBER, '1', 1),
+            makeToken(TokenType.PLUS, '+'),
+            makeToken(TokenType.NUMBER, '2', 2),
+            makeToken(TokenType.RIGHT_PAREN, ')'),
+            makeToken(TokenType.STAR, '*'),
+            makeToken(TokenType.NUMBER, '3', 3),
+            makeToken(TokenType.SEMICOLON, ';'),
+            makeToken(TokenType.EOF, '')
+        ]
+        const expr = (new Parser(tokens).parse() as any)[0].expression as Binary
+        expect(expr.operator.type).toBe(TokenType.STAR)
+        expect(expr.left).toBeInstanceOf(Grouping)
+
+        const inner = (expr.left as Grouping).expression as Binary
+        expect(inner).toBeInstanceOf(Binary)
+        expect(inner.operator.type).toBe(TokenType.PLUS)
+        expect((inner.left as Literal).value).toBe(1)
+        expect((inner.right as Literal).value).toBe(2)
+        expect((expr.right as Literal).value).toBe(3)
+    })
+
+    it('parses variable declaration CREATE x = 42;', () => {
+        const tokens = [
+            makeToken(TokenType.CREATE, 'CREATE'),
+            makeToken(TokenType.IDENTIFIER, 'x'),
+            makeToken(TokenType.EQUAL, '='),
+            makeToken(TokenType.NUMBER, '42', 42),
+            makeToken(TokenType.SEMICOLON, ';'),
+            makeToken(TokenType.EOF, '')
+        ]
+        const stmts = new Parser(tokens).parse()
+        expect(stmts).not.toBeNull()
+        const stmt = (stmts as any)[0]
+        expect(stmt).toBeInstanceOf(CreateStatement)
+        expect(stmt.name.lexeme).toBe('x')
+        const init = stmt.initializer
+        expect(init).toBeInstanceOf(Literal)
+        expect((init as Literal).value).toBe(42)
+    })
+
+    it('returns null on invalid assignment 1 = 2;', () => {
+        const tokens = [
+            makeToken(TokenType.NUMBER, '1', 1),
+            makeToken(TokenType.EQUAL, '='),
+            makeToken(TokenType.NUMBER, '2', 2),
+            makeToken(TokenType.SEMICOLON, ';'),
+            makeToken(TokenType.EOF, '')
+        ]
+        const result = new Parser(tokens).parse()
+        expect(result).toBeNull()
+    })
+})

--- a/src/lib/parser/Parser.test.ts
+++ b/src/lib/parser/Parser.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect } from 'vitest'
 import { Parser } from './Parser'
 import { Token, TokenType } from '../scanner/Token'
-import { ExpressionStatement, CreateStatement } from './statements'
-import { Binary, Literal, Grouping } from './expressions'
+import { BlockStatement, CreateStatement, ExpressionStatement, FunctionStatement, IfStatement, OutputStatement, ReturnStatement,
+    WhileStatement
+ } from './statements'
+import { Assign, Binary, Call, Grouping, Literal, Logical, Unary, Variable } from './expressions'
 
 function makeToken(type: TokenType, lexeme = type.toString(), literal: any = null) {
     return new Token(type, lexeme, literal, 1)
@@ -15,7 +17,7 @@ describe('Parser', () => {
             makeToken(TokenType.SEMICOLON, ';'),
             makeToken(TokenType.EOF, '')
         ]
-        
+
         const stmts = new Parser(tokens).parse()
         expect(stmts).not.toBeNull()
         expect(stmts).toHaveLength(1)
@@ -106,4 +108,224 @@ describe('Parser', () => {
         const result = new Parser(tokens).parse()
         expect(result).toBeNull()
     })
+
+    it('parses variable assignment x = 42;', () => {
+        const tokens = [
+            makeToken(TokenType.IDENTIFIER, 'x'),
+            makeToken(TokenType.EQUAL, '='),
+            makeToken(TokenType.NUMBER, '42', 42),
+            makeToken(TokenType.SEMICOLON, ';'),
+            makeToken(TokenType.EOF, '')
+        ]
+        const stmts = new Parser(tokens).parse()
+        expect(stmts).not.toBeNull()
+        const stmt = (stmts as any)[0]
+        expect(stmt).toBeInstanceOf(ExpressionStatement)
+        const expr = stmt.expression as Assign
+        expect(expr.name.lexeme).toBe('x')
+        expect(expr.value).toBeInstanceOf(Literal)
+        expect((expr.value as Literal).value).toBe(42)
+    })
+
+    it('parses logical expressions', () => {
+        const tokens = [
+            makeToken(TokenType.NUMBER, '1', 1),
+            makeToken(TokenType.OR, 'or'),
+            makeToken(TokenType.NUMBER, '2', 2),
+            makeToken(TokenType.AND, 'and'),
+            makeToken(TokenType.NUMBER, '3', 3),
+            makeToken(TokenType.SEMICOLON, ';'),
+            makeToken(TokenType.EOF, '')
+        ]
+        const expr = (new Parser(tokens).parse() as any)[0].expression as Logical
+        expect(expr).toBeInstanceOf(Logical)
+        expect(expr.operator.type).toBe(TokenType.OR)
+        expect(expr.left).toBeInstanceOf(Literal)
+        expect((expr.left as Literal).value).toBe(1)
+
+        const right = expr.right as Logical
+        expect(right).toBeInstanceOf(Logical)
+        expect(right.operator.type).toBe(TokenType.AND)
+        expect((right.left as Literal).value).toBe(2)
+        expect((right.right as Literal).value).toBe(3)
+    })
+
+    it('parses unary expressions', () => {
+        const tokens = [
+            makeToken(TokenType.MINUS, '-'),
+            makeToken(TokenType.NUMBER, '1', 1),
+            makeToken(TokenType.SEMICOLON, ';'),
+            makeToken(TokenType.EOF, '')
+        ]
+        const expr = (new Parser(tokens).parse() as any)[0].expression as Unary
+        expect(expr).toBeInstanceOf(Unary)
+        expect(expr.operator.type).toBe(TokenType.MINUS)
+        expect(expr.right).toBeInstanceOf(Literal)
+        expect((expr.right as Literal).value).toBe(1)
+    })
+
+    it('parses function calls', () => {
+        const tokens = [
+            makeToken(TokenType.IDENTIFIER, 'myFunction'),
+            makeToken(TokenType.LEFT_PAREN, '('),
+            makeToken(TokenType.NUMBER, '1', 1),
+            makeToken(TokenType.COMMA, ','),
+            makeToken(TokenType.NUMBER, '2', 2),
+            makeToken(TokenType.RIGHT_PAREN, ')'),
+            makeToken(TokenType.SEMICOLON, ';'),
+            makeToken(TokenType.EOF, '')
+        ]
+        const expr = (new Parser(tokens).parse() as any)[0].expression as Call
+        expect(expr).toBeInstanceOf(Call)
+        expect(expr.callee).toBeInstanceOf(Variable)
+        expect((expr.callee as Variable).name.lexeme).toBe('myFunction')
+        expect(expr.args).toHaveLength(2)
+        expect((expr.args[0] as Literal).value).toBe(1)
+        expect((expr.args[1] as Literal).value).toBe(2)
+    })
+
+    it('parses chained assignments x = y = 42;', () => {
+        const tokens = [
+            makeToken(TokenType.IDENTIFIER, 'x'),
+            makeToken(TokenType.EQUAL, '='),
+            makeToken(TokenType.IDENTIFIER, 'y'),
+            makeToken(TokenType.EQUAL, '='),
+            makeToken(TokenType.NUMBER, '42', 42),
+            makeToken(TokenType.SEMICOLON, ';'),
+            makeToken(TokenType.EOF, '')
+        ]
+        const stmts = new Parser(tokens).parse()
+        expect(stmts).not.toBeNull()
+        const stmt = (stmts as any)[0]
+        expect(stmt).toBeInstanceOf(ExpressionStatement)
+        const expr = stmt.expression as Assign
+        expect(expr.name.lexeme).toBe('x')
+        expect(expr.value).toBeInstanceOf(Assign)
+        const innerAssign = expr.value as Assign
+        expect(innerAssign.name.lexeme).toBe('y')
+        expect(innerAssign.value).toBeInstanceOf(Literal)
+        expect((innerAssign.value as Literal).value).toBe(42)
+    })
+
+        it('parses if statements', () => {
+        const tokens = [
+            makeToken(TokenType.IF, 'if'),
+            makeToken(TokenType.LEFT_PAREN, '('),
+            makeToken(TokenType.TRUE, 'true', true),
+            makeToken(TokenType.RIGHT_PAREN, ')'),
+            makeToken(TokenType.LEFT_BRACE, '{'),
+            makeToken(TokenType.OUTPUT, 'output'),
+            makeToken(TokenType.LEFT_PAREN, '('),
+            makeToken(TokenType.NUMBER, '1', 1),
+            makeToken(TokenType.RIGHT_PAREN, ')'),
+            makeToken(TokenType.SEMICOLON, ';'),
+            makeToken(TokenType.RIGHT_BRACE, '}'),
+            makeToken(TokenType.EOF, '')
+        ]
+    
+        const stmts = new Parser(tokens).parse()
+        expect(stmts).not.toBeNull()
+        expect(stmts).toHaveLength(1)
+    
+        const stmt = (stmts as any)[0]
+        expect(stmt).toBeInstanceOf(IfStatement)
+        const ifStmt = stmt as IfStatement
+    
+        // condition
+        expect(ifStmt.condition).toBeInstanceOf(Literal)
+        expect((ifStmt.condition as Literal).value).toBe(true)
+    
+        // then branch
+        expect(ifStmt.thenBranch).toBeInstanceOf(BlockStatement)
+        const block = ifStmt.thenBranch as BlockStatement
+        expect(block.statements).toHaveLength(1)
+    
+        const inner = block.statements[0]
+        expect(inner).toBeInstanceOf(OutputStatement)
+        const outputStmt = inner as OutputStatement
+        expect(outputStmt.expression).toBeInstanceOf(Literal)
+        expect((outputStmt.expression as Literal).value).toBe(1)
+    
+        // no else branch
+        expect(ifStmt.elseBranch).toBeNull()
+    })
+
+    it('parses return statements', () => {
+        const tokens = [
+            makeToken(TokenType.RETURN, 'return'),
+            makeToken(TokenType.NUMBER, '99', 99),
+            makeToken(TokenType.SEMICOLON, ';'),
+            makeToken(TokenType.EOF, '')
+        ];
+        const stmts = new Parser(tokens).parse();
+        expect(stmts).not.toBeNull();
+        expect(stmts).toHaveLength(1);
+    
+        const stmt = (stmts as any)[0];
+        expect(stmt).toBeInstanceOf(ReturnStatement);
+        const returnStmt = stmt as ReturnStatement;
+        expect(returnStmt.value).toBeInstanceOf(Literal);
+        expect((returnStmt.value as Literal).value).toBe(99);
+    });
+    
+    it('parses while statements', () => {
+        const tokens = [
+            makeToken(TokenType.WHILE, 'while'),
+            makeToken(TokenType.LEFT_PAREN, '('),
+            makeToken(TokenType.FALSE, 'false', false),
+            makeToken(TokenType.RIGHT_PAREN, ')'),
+            makeToken(TokenType.OUTPUT, 'output'),
+            makeToken(TokenType.LEFT_PAREN, '('),
+            makeToken(TokenType.NUMBER, '1', 1),
+            makeToken(TokenType.RIGHT_PAREN, ')'),
+            makeToken(TokenType.SEMICOLON, ';'),
+            makeToken(TokenType.EOF, '')
+        ];
+        const stmts = new Parser(tokens).parse();
+        expect(stmts).not.toBeNull();
+        expect(stmts).toHaveLength(1);
+    
+        const stmt = (stmts as any)[0];
+        expect(stmt).toBeInstanceOf(WhileStatement);
+        const whileStmt = stmt as WhileStatement;
+        expect(whileStmt.condition).toBeInstanceOf(Literal);
+        expect((whileStmt.condition as Literal).value).toBe(false);
+    
+        // body should be an ExpressionStatement or OutputStatement if inline
+        expect(whileStmt.body).toBeInstanceOf(OutputStatement);
+        const outputStmt = whileStmt.body as OutputStatement;
+        expect((outputStmt.expression as Literal).value).toBe(1);
+    });
+    
+    it('parses function declarations', () => {
+        const tokens = [
+            makeToken(TokenType.FUNC, 'function'),
+            makeToken(TokenType.IDENTIFIER, 'foo'),
+            makeToken(TokenType.LEFT_PAREN, '('),
+            makeToken(TokenType.RIGHT_PAREN, ')'),
+            makeToken(TokenType.LEFT_BRACE, '{'),
+                makeToken(TokenType.RETURN, 'return'),
+                makeToken(TokenType.NUMBER, '42', 42),
+                makeToken(TokenType.SEMICOLON, ';'),
+            makeToken(TokenType.RIGHT_BRACE, '}'),
+            makeToken(TokenType.EOF, '')
+        ];
+        const stmts = new Parser(tokens).parse();
+        expect(stmts).not.toBeNull();
+        expect(stmts).toHaveLength(1);
+    
+        const stmt = (stmts as any)[0];
+        expect(stmt).toBeInstanceOf(FunctionStatement);
+        const funcStmt = stmt as FunctionStatement;
+        expect(funcStmt.name.lexeme).toBe('foo');
+        expect(funcStmt.params).toEqual([]);
+        expect(funcStmt.body).toHaveLength(1);
+    
+        // body[0] should be the return statement
+        const bodyStmt = funcStmt.body[0];
+        expect(bodyStmt).toBeInstanceOf(ReturnStatement);
+        const ret = bodyStmt as ReturnStatement;
+        expect(ret.value).toBeInstanceOf(Literal);
+        expect((ret.value as Literal).value).toBe(42);
+    });
 })

--- a/src/lib/scanner/Scanner.test.ts
+++ b/src/lib/scanner/Scanner.test.ts
@@ -1,0 +1,96 @@
+import { expect, describe, it } from 'vitest';
+import { Scanner } from './Scanner';
+import { TokenType } from './Token';
+
+describe('Scanner', () => {
+    it('scans integer and float numbers', () => {
+        const tokens = new Scanner('123 45.67').scanTokens()!;
+        expect(tokens.map(t => t.type)).toEqual([
+            TokenType.NUMBER,
+            TokenType.NUMBER,
+            TokenType.EOF
+        ]);
+        expect(tokens[0].literal).toBe(123);
+        expect(tokens[1].literal).toBe(45.67);
+    });
+
+    it('scans simple and escaped string literals', () => {
+        const src = `"hello" "he said \\"wow\\"" "\\\\"`;
+        const tokens = new Scanner(src).scanTokens()!;
+        expect(tokens.map(t => t.type)).toEqual([
+            TokenType.STRING,
+            TokenType.STRING,
+            TokenType.STRING,
+            TokenType.EOF
+        ]);
+        expect(tokens[0].literal).toBe('hello');
+        expect(tokens[1].literal).toBe('he said "wow"');
+        expect(tokens[2].literal).toBe('\\');
+    });
+
+    it('recognizes identifiers and keywords with correct literals', () => {
+        const src = 'if else true false null not and or varName _var';
+        const tokens = new Scanner(src).scanTokens()!;
+        const types = tokens.map(t => t.type);
+        expect(types).toEqual([
+            TokenType.IF,
+            TokenType.ELSE,
+            TokenType.TRUE,
+            TokenType.FALSE,
+            TokenType.NULL,
+            TokenType.NOT,
+            TokenType.AND,
+            TokenType.OR,
+            TokenType.IDENTIFIER,
+            TokenType.IDENTIFIER,
+            TokenType.EOF
+        ]);
+        expect(tokens[2].literal).toBe(true);
+        expect(tokens[3].literal).toBe(false);
+        expect(tokens[4].literal).toBeNull();
+        expect(tokens[8].lexeme).toBe('varName');
+        expect(tokens[9].lexeme).toBe('_var');
+    });
+
+    it('scans various single and multi-character operators', () => {
+        const src = '(){}.,-+;*% != == < <= > >= /=';
+        const tokens = new Scanner(src).scanTokens()!;
+        const types = tokens.map(t => t.type);
+        expect(types).toEqual([
+            TokenType.LEFT_PAREN,
+            TokenType.RIGHT_PAREN,
+            TokenType.LEFT_BRACE,
+            TokenType.RIGHT_BRACE,
+            TokenType.DOT,
+            TokenType.COMMA,
+            TokenType.MINUS,
+            TokenType.PLUS,
+            TokenType.SEMICOLON,
+            TokenType.STAR,
+            TokenType.MODULO,
+            TokenType.BANG_EQUAL,
+            TokenType.EQUAL_EQUAL,
+            TokenType.LESS,
+            TokenType.LESS_EQUAL,
+            TokenType.GREATER,
+            TokenType.GREATER_EQUAL,
+            TokenType.SLASH,
+            TokenType.EQUAL,
+            TokenType.EOF
+        ]);
+    });
+
+    it('ignores comments and produces tokens after newline', () => {
+        const src = '// comment here\n+';
+        const tokens = new Scanner(src).scanTokens()!;
+        expect(tokens.map(t => t.type)).toEqual([TokenType.PLUS, TokenType.EOF]);
+    });
+
+    it('returns null on unterminated string literal', () => {
+        expect(new Scanner('"unterminated').scanTokens()).toBeNull();
+    });
+
+    it('returns null on unexpected characters', () => {
+        expect(new Scanner('@').scanTokens()).toBeNull();
+    });
+});


### PR DESCRIPTION
This pull request introduces several key updates, including adding a testing framework, enhancing the sample code, and implementing comprehensive unit tests for the `Parser` and `Scanner` components. These changes aim to improve code quality, maintainability, and functionality.

### Testing Framework Integration:
* Added `vitest` as a development dependency and included a `test` script in `package.json` to enable running tests. (`package.json`, [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L10-R11) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L35-R37)

### Enhancements to Sample Code:
* Expanded the `public/sample-code.cos` file to include a variety of programming constructs, such as variable declarations, arithmetic operations, conditionals, loops, unary operators, string and null literals, and function calls. This serves as a more comprehensive example of the language's capabilities. (`public/sample-code.cos`, [public/sample-code.cosR1-R59](diffhunk://#diff-25296583f686e97cde2bb597dd5cd3a4bbc9acb6cf9099b971ed559abcdce127R1-R59))

### Unit Tests for `Parser`:
* Added extensive tests in `src/lib/parser/Parser.test.ts` to validate the `Parser`'s ability to handle various constructs, including numeric literals, operator precedence, variable declarations, assignments, logical expressions, function calls, conditional statements, loops, and function declarations. (`src/lib/parser/Parser.test.ts`, [src/lib/parser/Parser.test.tsR1-R331](diffhunk://#diff-5c895fc1b798e8ba63f427da117c4525e997d053b4810a4d4d0aa94abc630ddaR1-R331))

### Unit Tests for `Scanner`:
* Introduced tests in `src/lib/scanner/Scanner.test.ts` to ensure the `Scanner` correctly identifies tokens for numbers, strings, keywords, operators, and handles edge cases like comments, unterminated strings, and unexpected characters. (`src/lib/scanner/Scanner.test.ts`, [src/lib/scanner/Scanner.test.tsR1-R96](diffhunk://#diff-2a1e57ac376c6aae5efa5a814f4cf5caacd91d09e3c03c94f6a05e59737e4572R1-R96))